### PR TITLE
Cleaning openpose repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /videos
 /data
 /.vscode/*
+/lib
+/playground

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,81 +1,63 @@
-# Initial variables
-# 1 
+# Base Ubuntu 
 ARG UBUNTU_VERSION=18.04
 # Nvidia CUDA and Deep Neuronal Networks libraries
-# 2
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu${UBUNTU_VERSION} as base
-# 3
+# For Building on Python and related
 ENV LANG C.UTF-8
 
-# 4
+# Development dependencies
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3.7-dev python3-pip git g++ wget make libprotobuf-dev protobuf-compiler libopencv-dev \
     libgoogle-glog-dev libboost-all-dev libcaffe-cuda-dev libhdf5-dev libatlas-base-dev liblapacke-dev
 
 # Numpy stack and opencv for python
-# 5 
 RUN pip3 install numpy opencv-python
 
-# X Server
-# 6
+# X Server and related
 RUN apt-get update && apt-get install -y x11-xserver-utils
 
 # Cmake 3.14 release version
-# 7
+# This is because current repo version of cmake generates problems
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.14.0/cmake-3.14.0-Linux-x86_64.tar.gz && \
     tar xzf cmake-3.14.0-Linux-x86_64.tar.gz -C /opt && \
     rm cmake-3.14.0-Linux-x86_64.tar.gz
-# 8 
+
+# Include the new cmake to the path env 
 ENV PATH="/opt/cmake-3.14.0-Linux-x86_64/bin:${PATH}"
 RUN apt update && apt install sudo
 
-# 9
 ARG USER_ID=1000
-# 10
 ARG GROUP_ID=1000
 
-# 11
+# Creates sim user and add to sudoers file
 RUN groupadd -g ${GROUP_ID} sim && \
     useradd -m -l -u ${USER_ID} -g sim sim && \
     echo "sim:sim" | chpasswd && adduser sim sudo && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# 12
+
 ENV HOME /home/sim
-# 13
 ENV SIM_ROOT=$HOME
 
 # Added to video group
-# 14
 RUN usermod -a -G video sim
-
-# 15
 USER sim
 
 # ======================OpenPose===========================
-# 16
 WORKDIR $HOME
-# RUN git clone --recurse-submodules https://github.com/kevinrev26/openpose.git
-# COPY openpose openpose
+# Cloning the repo, this includes osc 3rdparty library and simbotic.cpp demo
+RUN git clone --recurse-submodules https://github.com/kevinrev26/openpose.git
+# Creating building directory
+RUN mkdir -p $HOME/openpose/build
 
-# # RUN chmod -R 700 $HOME/openpose
+# Compiling OSCPack Library
+WORKDIR $HOME/openpose/3rdparty/oscpack
+RUN cmake -G "Unix Makefiles"
+RUN make
 
-# # RUN mkdir -p $HOME/openpose/build
-
-# ============
-# Friendly reminder: We must compile oscpack library
-# cmake -G "Unix Makefiles"
-# make
-# ============
-
-# WORKDIR $HOME/openpose/build
-# USER root
-# RUN chmod -R 777 $HOME/openpose
-# USER sim
+# Compiling openpose
+WORKDIR $HOME/openpose/build
 # # Building OpenPose
-# # 
-# RUN cmake -DBUILD_PYTHON=ON .. && make -j`nproc`
-# cmake -DBUILD_PYTHON=ON -DCMAKE_BUILD_TYPE=Debug ..
-# 17
+RUN cmake -DBUILD_PYTHON=ON .. && make -j`nproc`
 WORKDIR $HOME/openpose

--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ docker exec -it simbotic-openpose bash
 ## WebCam
 
 To support webcam through the container the device must be on `/dev/video0` otherwise you must change the `devices` to point to actual webcam.
+
+## Running simbotic example
+```
+docker exec -ti simbotic-openpose ./build/examples/simbotic/simbotic-openpose.bin
+```
+This will execute a binary using webcam and print the detected _keypoints_ on console.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,11 @@ services:
       - type: bind
         source: ${CURRENT_DIRECTORY}/data/
         target: /data
-      - type: bind
-        source: ./openpose/
-        target: /home/sim/openpose
+      - playground:/home/sim/openpose/examples
+volumes:
+  playground:
+    driver_opts:
+      type: none
+      device: ${CURRENT_DIRECTORY}/playground
+      o: bind
+    

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,6 @@
 
 echo "environment file created!"
 
-mkdir -p videos && mkdir -p data
+mkdir -p videos && mkdir -p data && mkdir -p playground
 
 echo "Directories for videos and data created"


### PR DESCRIPTION
This PR includes:
- Creates a playground directory that binds the examples on openpose.
- The submodule for openpose is removed since the project is compiled and building inside container.
- Updated version of dockerfile to build oscpack and openpose.
- Simbotic binary example.